### PR TITLE
Debug format

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ yarn add Askmos/logger
 
 ## Usage
 
+In your console, set your node environment to development to enable the development formatting:
+
+`export NODE_ENV=development`
+
+Then, inside your projects:
+
 ```javascript
 const logger = require('logger');
 

--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ logger.info('Message', context);
 logger.error('Error message', context);
 logger.debug('Debug messages', context);
 ```
+
+We use sprintf.js to support formatted string, you can check their [documentation](https://github.com/alexei/sprintf.js).
+
+For example:
+
+```javascript
+logger.silly('Sarting test with %j', obj);
+logger.info('Test with several objects %2j, and a string %s', obj, myString);`
+```
+
+The first log will output the object in a JSON format, inlined.
+The second one will add some padding to the first object, and add the string at the end of the log message.

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,4 @@
 const winston = require('winston');
-const { inspect } = require('util');
 const { vsprintf } = require('sprintf-js');
 
 const isDebug = process.env.NODE_ENV === 'development';
@@ -18,10 +17,17 @@ const addLambdaContextFormat = winston.format(info => (
   Object.assign(info, { stage: process.env.NODE_ENV })
 ));
 
+const sprintf = winston.format((info, opts) => {
+  const symbol = Object.getOwnPropertySymbols(info)[1];
+  info.message = vsprintf(info.message, info[symbol]);
+  return info;
+});
+
 // Display log as json for log aggregator for easy search
 let loggerFormat = combine(
   timestamp(),
   addLambdaContextFormat(),
+  sprintf(),
   json()
 );
 
@@ -32,10 +38,9 @@ if (isDebug) {
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
     colorize({ all: true }),
     align(),
+    sprintf(),
     printf((info) => {
-      const symbol = Object.getOwnPropertySymbols(info)[1];
-      const message = vsprintf(info.message, info[symbol]);
-      return `${info.timestamp} ${info.level}: ${message}}`;
+      return `[${info.timestamp}] ${info.level}: ${info.message}}`;
     })
   );
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,11 +1,14 @@
 const winston = require('winston');
 
+const isDebug = process.env.NODE_ENV === 'development'
+
 const {
   combine,
   timestamp,
   json,
   colorize,
-  simple
+  align,
+  printf
 } = winston.format;
 
 // Adding context to the log
@@ -21,14 +24,17 @@ let loggerFormat = combine(
 );
 
 // Display nicely in console for debug
-if (process.env.NODE_ENV === 'development') {
+if (isDebug) {
   loggerFormat = combine(
-    colorize(),
-    simple()
+    timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    align(),
+    colorize({ all: true }),
+    printf(info => `${info.timestamp} ${info.level}: ${info.message}`),
   );
 }
 
 module.exports = winston.createLogger({
+  level: isDebug ? 'silly' : 'info',
   format: loggerFormat,
   transports: [new winston.transports.Console()]
 });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,7 @@
 const winston = require('winston');
+const { inspect } = require('util');
 
-const isDebug = process.env.NODE_ENV === 'development'
+const isDebug = process.env.NODE_ENV === 'development';
 
 const {
   combine,
@@ -23,13 +24,18 @@ let loggerFormat = combine(
   json()
 );
 
+
 // Display nicely in console for debug
 if (isDebug) {
   loggerFormat = combine(
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
-    align(),
     colorize({ all: true }),
-    printf(info => `${info.timestamp} ${info.level}: ${info.message}`),
+    align(),
+    printf((info) => {
+      const symbol = Object.getOwnPropertySymbols(info)[1];
+      const message = vsprintf(info.message, info[symbol]);
+      return `${info.timestamp} ${info.level}: ${message}}`;
+    })
   );
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,8 +8,7 @@ const {
   timestamp,
   json,
   colorize,
-  align,
-  printf
+  printf,
 } = winston.format;
 
 // Adding context to the log
@@ -17,10 +16,18 @@ const addLambdaContextFormat = winston.format(info => (
   Object.assign(info, { stage: process.env.NODE_ENV })
 ));
 
-const sprintf = winston.format((info, opts) => {
-  const symbol = Object.getOwnPropertySymbols(info)[1];
-  info.message = vsprintf(info.message, info[symbol]);
+const getContextFromSplat = (info, splat) => {
+  if (!splat) return info;
+  splat.map(item => {
+    if (typeof item === 'object') Object.assign(info, item);
+  });
   return info;
+};
+
+const sprintf = winston.format((info) => {
+  const symbolSplat = Object.getOwnPropertySymbols(info)[1];
+  info.message = vsprintf(info.message, info[symbolSplat]);
+  return getContextFromSplat(info, info[symbolSplat]);
 });
 
 // Display log as json for log aggregator for easy search
@@ -31,18 +38,20 @@ let loggerFormat = combine(
   json()
 );
 
-
 // Display nicely in console for debug
 if (isDebug) {
   loggerFormat = combine(
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
     colorize({ all: true }),
-    align(),
     sprintf(),
     printf((info) => {
-      return `[${info.timestamp}] ${info.level}: ${info.message}}`;
+      const context = Object.assign({}, info);
+      delete context.message;
+      delete context.timestamp;
+      delete context.level;
+      return `[${info.timestamp}] ${info.level}: ${info.message}\ncontext: ${JSON.stringify(context,null,'  ')}`;
     })
-  );
+  )
 }
 
 module.exports = winston.createLogger({

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,6 @@
 const winston = require('winston');
 const { inspect } = require('util');
+const { vsprintf } = require('sprintf-js');
 
 const isDebug = process.env.NODE_ENV === 'development';
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "author": "David Zhang",
   "dependencies": {
+    "sprintf-js": "^1.1.1",
     "winston": "^3.0.0"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": ">=6.9.5"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "logger configuration for mos services",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,6 +134,10 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
+sprintf-js@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
+
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"


### PR DESCRIPTION
@zigzhang I find the syntax `logger.info('Message', context);` to be a bit verbose.

Could we move to something with a better readability using string interpolation ? 
Also, I don't see anything showing in logz.io is it setup yet ?